### PR TITLE
Removed decay in ajax update js

### DIFF
--- a/src/main/webapp/xfp.js
+++ b/src/main/webapp/xfp.js
@@ -103,6 +103,6 @@ Behaviour.addLoadEvent(function(){
         refreshUrl = refreshUrl + (refreshUrl.charAt(refreshUrl.length - 1) == "/" ? "" : "/") + "headlessdisplay";
     }
     new Ajax.PeriodicalUpdater("xfdisplay-dashboard", refreshUrl, {
-        method: 'get', frequency: refreshTime, decay: 2
+        method: 'get', frequency: refreshTime
     });
 });


### PR DESCRIPTION
Originally the decay should have reduced the load on the server,
but as the refresh time is now configurable and an immediate update
of the monitor is more important than a slightly reduced load on the server
this decay is not worth it anymore.
