### PR TITLE
Jenkins 16094

### DIFF
--- a/src/main/resources/maps/hudson/plugin/xfpanel/XFPanelView/configure-entries.jelly
+++ b/src/main/resources/maps/hudson/plugin/xfpanel/XFPanelView/configure-entries.jelly
@@ -94,6 +94,17 @@
 	<f:entry title="${%Show warning icon}" field="showWarningIcon">
 		<f:checkbox id="xfpanel.showWarningIcon" name="showWarningIcon" checked="${it.showWarningIcon}" value="true"/>
 	</f:entry>
+
+	<j:if test="${it.hasJobFilterExtensions()}">
+		<j:invokeStatic var="allJobFilters" className="hudson.views.ViewJobFilter" method="all"/>
+		<f:block>
+			<f:hetero-list name="jobFilters" hasHeader="true"
+				descriptors="${allJobFilters}"
+				items="${it.jobFilters}"
+				addCaption="${%Add Job Filter}" />
+		</f:block>
+	</j:if>
+
   </f:section>
 
   <f:section title="${%General options}">


### PR DESCRIPTION
These commits implement the requested support for the view-job-filters plugin from https://issues.jenkins-ci.org/browse/JENKINS-16094

A secondary change is to replace the html markup for the section headers in the configure-entries.jelly script with standard jenkins tags
