### PR TITLE
Prepend context path to job page URLs

### DIFF
--- a/src/main/resources/maps/hudson/plugin/xfpanel/XFPanelView/job.jelly
+++ b/src/main/resources/maps/hudson/plugin/xfpanel/XFPanelView/job.jelly
@@ -9,7 +9,7 @@
 	<j:set var="claimTopMargin" value="${from.guiFailFont*0.2}px" />
 
 	<!-- JOB div -->
-	<a href="${job.url}" style="font-style:normal; font-weight:bold;">
+	<a href="${rootURL}/${job.url}" style="font-style:normal; font-weight:bold;">
 		<div align="center" style="margin: 4px; background-color:${job.backgroundColor}; -moz-border-radius:10px; width:${width}; height:${height}; float: ${float}" tooltip="${job.name}">
 			<j:set var="failColor" value="#00FF00" />
 			<j:if test="${job.failCount > 0}">


### PR DESCRIPTION
When linking to individual job pages in the XF panel view, the generated job page URLs are missing the context path, i. e. they are relative -- and thus lead to non-existing pages, giving the user a "404 Not Found" page. This pull request fixes that by prepending [`rootURL`](https://wiki.jenkins-ci.org/display/JENKINS/Hyperlinks+in+HTML) to the job page URLs.
