### PR TITLE
    JENKINS-28064   'Replace nr. of failed test cases' option doesn't work 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <!-- which version of Hudson is this plugin built against? -->
-        <version>1.610</version>
+        <!-- which version of Hudson is this plugin built against? synchronized with Claim plugin-->
+        <version>1.577</version>
     </parent>
 
     <artifactId>xfpanel</artifactId>
@@ -65,7 +65,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		    <powermock.version>1.6.2</powermock.version>
+        <powermock.version>1.6.2</powermock.version>
     </properties>
 
     <pluginRepositories>
@@ -128,23 +128,23 @@
             <artifactId>jna</artifactId>
             <version>3.2.2</version>
         </dependency>
-				<dependency>
-				  <groupId>org.easymock</groupId>
-				  <artifactId>easymock</artifactId>
-				  <version>3.3.1</version>
-				  <scope>test</scope>
-				</dependency>
-			   <dependency>
-			      <groupId>org.powermock</groupId>
-			      <artifactId>powermock-module-junit4</artifactId>
-			      <version>${powermock.version}</version>
-			      <scope>test</scope>
-			   </dependency>
-			   <dependency>
-			      <groupId>org.powermock</groupId>
-			      <artifactId>powermock-api-easymock</artifactId>
-			      <version>${powermock.version}</version>
-			      <scope>test</scope>
-			   </dependency>
+        <dependency>
+          <groupId>org.easymock</groupId>
+          <artifactId>easymock</artifactId>
+          <version>3.3.1</version>
+          <scope>test</scope>
+        </dependency>
+         <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+         </dependency>
+         <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-easymock</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>xfpanel</artifactId>
     <packaging>hpi</packaging>
     <name>eXtreme Feedback Panel</name>
-    <version>1.2.4-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <description>Provides an eXtreme Feedback Panel for Hudson. Thanks to Mark Howard and his work on the Radiator View
         Plugin from which this was based.
     </description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <!-- which version of Hudson is this plugin built against? -->
-        <version>1.532</version>
+        <version>1.475</version>
     </parent>
 
     <artifactId>xfpanel</artifactId>
@@ -117,11 +117,6 @@
             <groupId>org.jvnet.hudson.plugins</groupId>
             <artifactId>claim</artifactId>
             <version>1.7</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>junit</artifactId>
-            <version>1.5</version>
         </dependency>
         <dependency>
             <groupId>net.java.dev.jna</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <!-- which version of Hudson is this plugin built against? synchronized with Claim plugin-->
-        <version>1.577</version>
+        <!-- which version of Hudson is this plugin built against? -->
+        <version>1.509</version>
     </parent>
 
     <artifactId>xfpanel</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <!-- which version of Hudson is this plugin built against? -->
-        <version>1.475</version>
+        <version>1.610</version>
     </parent>
 
     <artifactId>xfpanel</artifactId>
@@ -65,6 +65,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		    <powermock.version>1.6.2</powermock.version>
     </properties>
 
     <pluginRepositories>
@@ -118,9 +119,32 @@
             <version>1.7</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>junit</artifactId>
+            <version>1.5</version>
+        </dependency>
+        <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
             <version>3.2.2</version>
         </dependency>
+				<dependency>
+				  <groupId>org.easymock</groupId>
+				  <artifactId>easymock</artifactId>
+				  <version>3.3.1</version>
+				  <scope>test</scope>
+				</dependency>
+			   <dependency>
+			      <groupId>org.powermock</groupId>
+			      <artifactId>powermock-module-junit4</artifactId>
+			      <version>${powermock.version}</version>
+			      <scope>test</scope>
+			   </dependency>
+			   <dependency>
+			      <groupId>org.powermock</groupId>
+			      <artifactId>powermock-api-easymock</artifactId>
+			      <version>${powermock.version}</version>
+			      <scope>test</scope>
+			   </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
         <!-- which version of Hudson is this plugin built against? -->
-        <version>1.509</version>
+        <version>1.532</version>
     </parent>
 
     <artifactId>xfpanel</artifactId>

--- a/src/test/java/maps/hudson/plugin/xfpanel/XFPanelEntryTest.java
+++ b/src/test/java/maps/hudson/plugin/xfpanel/XFPanelEntryTest.java
@@ -1,0 +1,122 @@
+package maps.hudson.plugin.xfpanel;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import jenkins.model.Jenkins;
+import hudson.DescriptorExtensionList;
+import hudson.Plugin;
+import hudson.model.BallColor;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import hudson.model.FreeStyleBuild;
+import hudson.model.AbstractBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.plugins.claim.ClaimTestAction;
+import hudson.tasks.junit.TestResult;
+import hudson.tasks.junit.TestResultAction;
+import hudson.tasks.junit.CaseResult;
+import hudson.tasks.test.AbstractTestResultAction;
+import hudson.views.ListViewColumn;
+
+import maps.hudson.plugin.xfpanel.XFPanelView.XFPanelColors;
+
+import org.easymock.ConstructorArgs;
+import org.easymock.EasyMock;
+import org.easymock.EasyMockSupport;
+import org.easymock.IMockBuilder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.PowerMock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest( {TestResult.class, XFPanelEntry.class, XFPanelColors.class })
+public class XFPanelEntryTest {
+
+	@Test
+	public void testOneClaimed() throws Exception {
+		XFPanelEntry xfPanelEntry = prepareData(3, true, true);
+		assertEquals("2", xfPanelEntry.getNumberOfTests());
+	}
+	@Test
+	public void testNoneClaimed() throws Exception {
+		XFPanelEntry xfPanelEntry = prepareData(4, false, true);
+		assertEquals("4", xfPanelEntry.getNumberOfTests());
+		//verifyAll();
+	}
+	@Test
+	public void testAllFailed() throws Exception {
+		XFPanelEntry xfPanelEntry = prepareData(4, true, false);
+		assertEquals("4", xfPanelEntry.getNumberOfTests());
+		//verifyAll();
+	}
+
+	private XFPanelEntry prepareData(int allFailed, boolean oneClaimed, boolean showClaimed) throws NoSuchFieldException,
+			IllegalAccessException {
+		Field field = Jenkins.class.getDeclaredField("theInstance");
+    field.setAccessible(true);
+    Jenkins jenkins = PowerMock.createNiceMock(Jenkins.class);
+    field.set(null, jenkins);
+    //EasyMock.expect(jenkins.getInstance()).andReturn(jenkins);
+    //<T extends Describable<T>, D extends Descriptor<T>> 
+    DescriptorExtensionList del = PowerMock.createNiceMock(DescriptorExtensionList.class);
+    List<String> al = new ArrayList<String>();
+    EasyMock.expect(del.iterator()).andReturn(al.iterator());
+    EasyMock.expect(jenkins.getDescriptorList(ListViewColumn.class)).andReturn(del);
+		FreeStyleProject project = PowerMock.createNiceMock(FreeStyleProject.class);
+		Job job = project;
+		XFPanelView view = PowerMock.createNiceMock(XFPanelView.class);
+		EasyMock.expect(view.getDisplayName()).andReturn("testview");
+		EasyMock.expect(job.getIconColor()).andReturn(BallColor.BLUE);
+		XFPanelColors xfPanelColors = PowerMock.createNiceMock(XFPanelColors.class);
+		EasyMock.expect(view.getColors()).andReturn(xfPanelColors).anyTimes();
+		PowerMock.replayAll();
+		
+//		XFPanelEntry xfPanelEntry = PowerMock.createMock(XFPanelEntry.class,
+//				view, job);
+		XFPanelEntry xfPanelEntry = new XFPanelEntry(view, job);
+		PowerMock.resetAll();
+		
+		EasyMock.expect(view.getIsClaimPluginInstalled()).andReturn(true).anyTimes();
+		EasyMock.expect(view.getReplaceNumberOfTestCases()).andReturn(showClaimed).anyTimes();
+
+		AbstractBuild lastBuild = PowerMock.createNiceMock(AbstractBuild.class);
+		AbstractTestResultAction atra = PowerMock.createNiceMock(AbstractTestResultAction.class);
+		EasyMock.expect(atra.getFailCount()).andReturn(allFailed);
+		EasyMock.expect(lastBuild.getAction(AbstractTestResultAction.class)).andReturn(atra);
+		
+		TestResult testResult = PowerMock.createNiceMock(TestResult.class);
+
+    List<CaseResult> crl = new ArrayList<CaseResult>();
+		CaseResult cr = PowerMock.createNiceMock(CaseResult.class);
+		ClaimTestAction cta = PowerMock.createNiceMock(ClaimTestAction.class);
+		EasyMock.expect(cta.isClaimed()).andReturn(oneClaimed);
+		EasyMock.expect(cr.getTestAction(ClaimTestAction.class)).andReturn(cta);
+		crl.add(cr);
+
+		EasyMock.expect(testResult.getTotalCount()).andReturn(-1); //whatever
+		EasyMock.expect(testResult.getFailedTests()).andReturn(crl);
+		
+		TestResultAction tra = PowerMock.createNiceMock(TestResultAction.class);
+		EasyMock.expect(tra.getResult()).andReturn(testResult);
+		List<TestResultAction> tral = new ArrayList<TestResultAction>();
+		tral.add(tra);
+
+		EasyMock.expect(lastBuild.getActions(TestResultAction.class)).andReturn(tral);
+		EasyMock.expect(job.getLastSuccessfulBuild()).andReturn(lastBuild).anyTimes();
+		EasyMock.expect(job.getLastBuild()).andReturn(lastBuild).anyTimes();
+
+    EasyMock.expect(jenkins.getPlugin("claim")).andReturn(new Plugin.DummyImpl()).anyTimes();
+		
+		PowerMock.replayAll();
+		assertNotNull(Jenkins.getInstance().getPlugin("claim"));
+		return xfPanelEntry;
+	}
+}

--- a/src/test/java/maps/hudson/plugin/xfpanel/XFPanelEntryTest.java
+++ b/src/test/java/maps/hudson/plugin/xfpanel/XFPanelEntryTest.java
@@ -37,7 +37,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest( {TestResult.class, XFPanelEntry.class, XFPanelColors.class })
+@PrepareForTest( {TestResult.class, XFPanelEntry.class, XFPanelColors.class, CaseResult.class })
 public class XFPanelEntryTest {
 
 	@Test


### PR DESCRIPTION
fix for bug     JENKINS-28064 

'Replace nr. of failed test cases' option doesn't work 

Fundametal error - XFPanelEntry exteded XFPanelView, but it shouldn't. The bug appeared because in XFPanelView.sort XFPanelEntry have been created, but it's properties not initialized - so the flag replaceNumberOfTestCases was always default(true) on entry. Fixing 'inheritance' error fixed this problem as well.
Additionally there is a test using mocks.
