### PR TITLE
Fixes corrupt layout due to a missing css style

### DIFF
--- a/src/main/resources/maps/hudson/plugin/xfpanel/XFPanelView/maindisplay.jelly
+++ b/src/main/resources/maps/hudson/plugin/xfpanel/XFPanelView/maindisplay.jelly
@@ -21,7 +21,7 @@
 		</j:when>
 		<j:otherwise>
 			<div class="dashboard"
-				style="left: 0px; top: 34px; position: absolute; height: 100%; z-index: 9999; width: 100%; background-color: white; text-align: center;">
+				style="left: 0px; top: 34px; position: absolute; height: 100%; z-index: 9999; width: 100%; background-color: white; text-align: center; line-height: normal;">
 
 				<j:invoke var="jobs" on="${from}" method="sort">
 					<j:arg type="java.util.Collection" value="${items}" />


### PR DESCRIPTION
With Jenkins 2.7 (at least with that version I saw this bug) the layout of the job container is corrupt. All texts are pinned to the top of the container they belong to and overlap each other.

This plugin is unusable with that problem and I consider it as a blocker.

In this PR you'll find a simple and small fix that solves the problem.
