### PR TITLE
jobNameReplaceRegExpPattern is not changed if jobNameReplaceRegExp is changed

### DIFF
--- a/src/main/java/maps/hudson/plugin/xfpanel/XFPanelView.java
+++ b/src/main/java/maps/hudson/plugin/xfpanel/XFPanelView.java
@@ -83,7 +83,7 @@ public class XFPanelView extends ListView {
     private String otherBuildColor = "#CCCCCC";
     private String buildFontColor = "#FFFFFF";
     
-		private String jobNameReplaceRegExp;
+    private String jobNameReplaceRegExp;
     private String jobNameReplacement;
     private Pattern jobNameReplaceRegExpPattern;
 
@@ -163,7 +163,7 @@ public class XFPanelView extends ListView {
         }
         return this.showDescription;
     }
-
+    
     public Boolean getShowBrokenBuildCount() {
         if (this.showBrokenBuildCount == null) {
             this.showBrokenBuildCount = Boolean.FALSE;;
@@ -531,9 +531,10 @@ public class XFPanelView extends ListView {
         else if (blameType.equals("blame.everyInvolved")) {
             this.BlameState = Blame.EVERYINVOLVED;
         }
+        
         this.jobNameReplaceRegExp = req.getParameter("jobNameReplaceRegExp");
         this.jobNameReplacement = req.getParameter("jobNameReplacement");
-        
+        this.jobNameReplaceRegExpPattern = null;
     }
 
     private Integer asInteger(StaplerRequest request, String parameterName) throws FormException {


### PR DESCRIPTION
The plugin allows the user to replace the job name according to a given pattern. This pattern is internally compiled and saved in the `jobNameReplaceRegExpPattern` field.

As soon as I change the pattern in the `configure` website on Jenkins the plugin should change it internally, too. But atm the change is ignored because the field is already filled with the old pattern.

To solve this issue, we have to null the pattern field if the pattern is changed. This PR solves that issue. 
