### PR TITLE
Removed unneeded and bad cast

### DIFF
--- a/src/main/java/maps/hudson/plugin/xfpanel/XFPanelEntry.java
+++ b/src/main/java/maps/hudson/plugin/xfpanel/XFPanelEntry.java
@@ -430,7 +430,7 @@ public final class XFPanelEntry {
             }
             // if building check previous status
             if (lastBuild.isBuilding()){
-                lastBuild = (AbstractBuild<?, ?>) lastBuild.getPreviousBuild();
+                lastBuild = lastBuild.getPreviousBuild();
                 if (lastBuild == null){
                     return null;
                 }


### PR DESCRIPTION
This cast will fail in some cases, for example if the job is a pipeline job. As the getActions method is already available on the Run interface it is not needed. Should [FIXED JENKINS-38524]
